### PR TITLE
serverless deployment using zeit.co now

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "package.json", "use": "@now/static-build" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "nuxt start",
     "generate": "nuxt generate",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore .",
-    "precommit": "npm run lint"
+    "precommit": "npm run lint",
+    "now-build": "nuxt generate"
   },
   "dependencies": {
     "@mdi/font": "^3.6.95",


### PR DESCRIPTION
serverless deployment to [now](https://zeit.co/home)
demo link: [https://nuxtdemo.ganyizhong.now.sh/](https://nuxtdemo.ganyizhong.now.sh/)
